### PR TITLE
Align bower.json with zurb foundation 5.0.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,6 +8,7 @@
   ],
   "dependencies": {
     "jquery": ">= 2.0.0",
-    "modernizr": ">= 2.6.2"
+    "modernizr": ">= 2.6.2",
+    "normalize-css": "2.1.2"
   }
 }


### PR DESCRIPTION
Hello,

I have re-aligned bower.json with the bower.json of the official repository.
Just added "normalize-css" dependency.

Remeber to update the 5.0.2 tag after the merge :wink: 

-Éric
