### PR TITLE
Use components-* version of modernizr package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "jquery": ">= 2.1.0",
-    "modernizr": ">= 2.7.2",
+    "components-modernizr": ">= 2.7.2",
     "fastclick": ">=0.6.11",
     "jquery.cookie": "~1.4.0",
     "jquery-placeholder": "~2.0.7"


### PR DESCRIPTION
Modernizr doesn't have a bower.json (as of version 2.8.3), and some build tools (brunch.io) depend on this to work properly (so they can see which files need to be concatenated via the "main" property). Using the components-modernizr version of the package will allow those build tools to work without any hacks/overrides.